### PR TITLE
Fix footer Learn Angular link URL typo

### DIFF
--- a/_partials/footer.ejs
+++ b/_partials/footer.ejs
@@ -6,7 +6,7 @@
             </div>
             <div class="mdl-cell mdl-cell--2-col mdl-cell--12-col-tablet footer-links">
                 <ul class="footer-links">
-                    <li> <a class="" href="https://wwww.angular.io">Learn Angular</a> </li>
+                    <li> <a class="" href="https://www.angular.io">Learn Angular</a> </li>
                 </ul>
             </div>
             <div class="mdl-cell mdl-cell--9-col">


### PR DESCRIPTION
The "Learn Angular" link is broken in the footer of all the Angular microsites built from https://github.com/angular/microsites.

Instead of `www.angular.io`, the link target is `wwww.angular.io` (note the extra **w**).

The [README](https://github.com/angular/microsites/blob/master/README.md) in the microsites repo refers to the microsite-ui package as https://github.com/ericjim/microsite-ui, which no longer exists.  As best I can tell, the microsites are being built from this [angular/design-love](https://github.com/angular/design-love) repo.